### PR TITLE
iOS 11

### DIFF
--- a/Datadog.podspec
+++ b/Datadog.podspec
@@ -10,10 +10,10 @@ Pod::Spec.new do |s|
   s.authors            = { "Kris Woodall" => "k.woodall@remind101.com" }
 
   s.swift_version      = '5.1'
-  s.ios.deployment_target = '12.0'
+  s.ios.deployment_target = '11.0'
   s.osx.deployment_target = '10.14'
 
-  s.source = { :git => 'https://github.com/remind101/dd-sdk-ios', :tag => s.version.to_s }
+  s.source = { :git => 'https://github.com/remind101/dd-sdk-ios.git', :tag => s.version.to_s }
 
   s.source_files = "Sources/Datadog/**/*.swift"
 end

--- a/Package.swift
+++ b/Package.swift
@@ -5,7 +5,7 @@ import PackageDescription
 let package = Package(
     name: "Datadog",
     platforms: [
-        .iOS(.v12),
+        .iOS(.v11),
         .macOS(.v10_14),
     ],
     products: [

--- a/Sources/Datadog/Core/System/CarrierInfoProvider.swift
+++ b/Sources/Datadog/Core/System/CarrierInfoProvider.swift
@@ -35,6 +35,7 @@ internal protocol CarrierInfoProviderType {
     var current: CarrierInfo? { get }
 }
 
+@available (iOS 12.0, *)
 internal class CarrierInfoProvider: CarrierInfoProviderType {
     #if os(iOS)
     private let networkInfo: CTTelephonyNetworkInfo

--- a/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
+++ b/Sources/Datadog/Core/System/NetworkConnectionInfoProvider.swift
@@ -39,6 +39,7 @@ internal protocol NetworkConnectionInfoProviderType {
     var current: NetworkConnectionInfo { get }
 }
 
+@available (iOS 12.0, *)
 internal class NetworkConnectionInfoProvider: NetworkConnectionInfoProviderType {
     private let queue = DispatchQueue.global(qos: .utility)
     private let monitor: NWCurrentPathMonitor
@@ -90,6 +91,7 @@ internal class NetworkConnectionInfoProvider: NetworkConnectionInfoProviderType 
 // MARK: - Utilities
 
 /// Utility protocol to inject `NWPathMonitor` to `NetworkConnectionInfoProvider`.
+@available (iOS 12.0, *)
 internal protocol NWCurrentPathMonitor {
     func start(queue: DispatchQueue)
     func cancel()
@@ -97,6 +99,7 @@ internal protocol NWCurrentPathMonitor {
 }
 
 /// Utility type to aggregate current path info provided by `NWPathMonitor`,
+@available (iOS 12.0, *)
 internal struct NWCurrentPathInfo {
     let availableInterfaceTypes: [NWInterface.InterfaceType]
     let status: NWPath.Status
@@ -107,6 +110,7 @@ internal struct NWCurrentPathInfo {
 }
 
 /// Apple's `NWPathMonitor` conformance to utility `NWCurrentPathMonitor`.
+@available (iOS 12.0, *)
 extension NWPathMonitor: NWCurrentPathMonitor {
     func currentPathInfo() -> NWCurrentPathInfo {
         let isCurrentPathConstrained: Bool? = {

--- a/Sources/Datadog/Datadog.swift
+++ b/Sources/Datadog/Datadog.swift
@@ -50,6 +50,7 @@ public class Datadog {
     /// - Parameters:
     ///   - appContext: context passing information about the app.
     ///   - configuration: the SDK configuration obtained using `Datadog.Configuration.builderUsing(clientToken:)`.
+    @available (iOS 12.0, *)
     public static func initialize(appContext: AppContext, configuration: Configuration) {
         do {
             try initializeOrThrow(appContext: appContext, configuration: configuration)
@@ -84,6 +85,7 @@ public class Datadog {
     internal let logsPersistenceStrategy: LogsPersistenceStrategy
     internal let logsUploadStrategy: LogsUploadStrategy
 
+    @available (iOS 12.0, *)
     private static func initializeOrThrow(appContext: AppContext, configuration: Configuration) throws {
         guard Datadog.instance == nil else {
             throw ProgrammerError(description: "SDK is already initialized.")

--- a/Sources/DatadogObjc/Datadog+objc.swift
+++ b/Sources/DatadogObjc/Datadog+objc.swift
@@ -26,6 +26,7 @@ public class DDAppContext: NSObject {
 public class DDDatadog: NSObject {
     // MARK: - Public
 
+    @available (iOS 12.0, *)
     public static func initialize(appContext: DDAppContext, configuration: DDConfiguration) {
         Datadog.initialize(
             appContext: appContext.sdkAppContext,


### PR DESCRIPTION
### What and why?
Updating this package's deployment target to iOS 11.

### How?
Updates to the podspec definition and Package.swift definition. `@available(iOS 12, *)` annotations to make required things unavailable to iOS 11.